### PR TITLE
feat(sigs): capture inline param docstrings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 141
+  Max: 145
 
 # Offense count: 3
 # Configuration parameters: IgnoredMethods.

--- a/spec/data/sig_handler.rb.txt
+++ b/spec/data/sig_handler.rb.txt
@@ -153,6 +153,15 @@ class SigParams
   def blk_method(&blk); nil; end
 
   sig do
+    params(
+      one: String, # First param
+      # Second param
+      two: Number,
+    ).void
+  end
+  def inline_param_doc_method(one, two); end
+
+  sig do
     override
     .params(block: T.proc.params(
       model: EmailConversation,

--- a/spec/yard_sorbet/sig_handler_spec.rb
+++ b/spec/yard_sorbet/sig_handler_spec.rb
@@ -185,6 +185,14 @@ RSpec.describe YARDSorbet::SigHandler do
       expect(node.tag(:return).types).to eq(['void'])
     end
 
+    it 'param with inline comments' do
+      node = YARD::Registry.at('SigParams#inline_param_doc_method')
+      one_tag = node.tags.find { |t| t.name == 'one' }
+      expect(one_tag.text).to eql('First param')
+      two_tag = node.tags.find { |t| t.name == 'two' }
+      expect(two_tag.text).to eql('Second param')
+    end
+
     it 'T::Array' do
       node = YARD::Registry.at('CollectionSigs#collection')
       param_tag = node.tags.find { |t| t.name == 'arr' }


### PR DESCRIPTION
This updates our fork of yard-sorbet to capture inline parameter documentation. We could also just monkey patch this inside of gem-core, but 1) the code isn't structured in such a way that would allow us to do that without copy-pasting a bunch of code, and 2) I think there's also a possibility that we can get this merged upstream as well.